### PR TITLE
Change repo link

### DIFF
--- a/LANDING.md
+++ b/LANDING.md
@@ -37,6 +37,6 @@ Piano VR
 # SourceCode
 | name | link |
 | - | - |
-| GitHub | https://github.com/pushkinman/Piano_Quest |
+| GitHub | https://github.com/RTUITLab/Piano_Quest |
 
 ---


### PR DESCRIPTION
Кажется в репозитории RTUITLab стоит указать ссылку на организацию RTUITLab, а не на личный аккаунт